### PR TITLE
roles in Eventdetails depend on CreatorsID instead od username

### DIFF
--- a/app/src/main/java/com/example/insightsshare/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/insightsshare/EventDetailsActivity.java
@@ -34,7 +34,7 @@ public class EventDetailsActivity extends AppCompatActivity {
     ValueEventListener eventListener;
 
     // View elements
-    String eventId;
+    String eventId, eventCreatorsID;
     TextView eventName, eventCreator, eventCreationDate, eventPlace, eventDate, eventTime, eventDescription;
     RecyclerView participantsView;
     LinearLayout bottomContainer, participantsInfo, eventControl;
@@ -94,6 +94,7 @@ public class EventDetailsActivity extends AppCompatActivity {
 
                 eventName.setText(eventItem.getEventName());
                 eventCreator.setText(eventItem.getEventCreator());
+                eventCreatorsID=eventItem.getEventCreatorsID();
                 eventCreationDate.setText(eventItem.getEventCreationDate());
                 eventDate.setText(eventItem.getEventDate());
                 eventTime.setText(eventItem.getEventTime());
@@ -116,7 +117,7 @@ public class EventDetailsActivity extends AppCompatActivity {
                     @Override
                     public void onDataChange(@NonNull DataSnapshot userSnapshot) {
                         UserClass userClass = userSnapshot.getValue(UserClass.class);
-                        if (userClass.getUsername().equals(eventCreator.getText().toString())) {
+                        if (userClass.getUserID().equals (eventCreatorsID)) {
                             setCreatorView();
                         } else if (listSnapshot.child("participantsList").hasChild(user.getUid())){
                             setParticipantView();

--- a/app/src/main/java/com/example/insightsshare/EventItem.java
+++ b/app/src/main/java/com/example/insightsshare/EventItem.java
@@ -2,7 +2,7 @@ package com.example.insightsshare;
 
 public class EventItem {
 
-    public String eventId, eventName, eventDescription, eventCreator, eventCreationDate, eventPlace,
+    public String eventId, eventName, eventDescription, eventCreator, eventCreatorsID, eventCreationDate, eventPlace,
             eventDate, eventTime, maxParticipants;
 
     public EventItem() {
@@ -10,12 +10,13 @@ public class EventItem {
      }
 
 
-    public EventItem(String eventId, String eventName, String eventDescription, String eventCreator, String eventCreationDate,
+    public EventItem(String eventId, String eventName, String eventDescription, String eventCreator, String eventCreatorsID, String eventCreationDate,
                      String eventPlace, String eventDate, String eventTime, String maxParticipants) {
         this.eventId = eventId;
         this.eventName = eventName;
         this.eventDescription= eventDescription;
         this.eventCreator = eventCreator;
+        this.eventCreatorsID= eventCreatorsID;
         this.eventCreationDate = eventCreationDate;
         this.eventPlace = eventPlace;
         this.eventDate = eventDate;
@@ -50,6 +51,10 @@ public class EventItem {
     public void setEventCreator(String eventCreator) {
         this.eventCreator = eventCreator;
     }
+
+    public String getEventCreatorsID() { return eventCreatorsID; }
+
+    public void setEventCreatorsID(String eventCreatorsID) { this.eventCreatorsID = eventCreatorsID; }
 
     public String getEventCreationDate() {
         return eventCreationDate;

--- a/app/src/main/java/com/example/insightsshare/EventplanningActivity5.java
+++ b/app/src/main/java/com/example/insightsshare/EventplanningActivity5.java
@@ -50,6 +50,7 @@ public class EventplanningActivity5 extends AppCompatActivity {
     TextView eventCreator;
     EditText eventName, eventDescription, eventPlace, maxParticipants;
     Button ButtonSave;
+    String eventCreatorsID;
 
     //variables for updating existing Eventdata
     Boolean updateExistingEvent = false; // False as default
@@ -92,6 +93,7 @@ public class EventplanningActivity5 extends AppCompatActivity {
             public void onDataChange(@NonNull DataSnapshot snapshot) {
                 UserClass userClass = snapshot.getValue(UserClass.class);
                 eventCreator.setText(userClass.getUsername());
+                eventCreatorsID=userClass.getUserID();
             }
 
             @Override
@@ -147,10 +149,6 @@ public class EventplanningActivity5 extends AppCompatActivity {
             rootNode = FirebaseDatabase.getInstance("https://insightsshare-1e407-default-rtdb.europe-west1.firebasedatabase.app");
             reference = rootNode.getReference().child("Event");
 
-            //TODO There must be a userID of the creator attached to an event, so that the Eventdatails can assign the roles:
-            // creator, participant or nonparticipant by the id and not the username.
-            // The current version can be exploited by changing your profilename to the name of an eventcreator to change their event or delete it :(
-
             //decides between creating a new Event or updating an existing Event
             if (!updateExistingEvent) {
                 //get all the values of the data (input) in stings so it can be stored
@@ -163,10 +161,11 @@ public class EventplanningActivity5 extends AppCompatActivity {
                 String ValueMaxParticipants = maxParticipants.getEditableText().toString();
                 String todayStr = getTodaysDate();
                 String ValueEventCreator = eventCreator.getText().toString();
+                String valueEventCreatorsID=eventCreatorsID;
 
                 //here the data is collected (to be send to the DB in the next step)
                 EventItem eventEntry = new EventItem(ValueEventId, ValueEventName, ValueEventDescription,
-                        ValueEventCreator, todayStr, ValuePlace, ValueDate, ValueTime, ValueMaxParticipants);
+                        ValueEventCreator, valueEventCreatorsID, todayStr, ValuePlace, ValueDate, ValueTime, ValueMaxParticipants);
 
                 //data is stored in the DB
                 assert ValueEventId != null;


### PR DESCRIPTION
Issue #56  resolved

Before it was possible to change ones name to temper with events of other persones. Now that is no longer possible, because in the process of creating an event the CreatorsID will be saved in the database too. Later in the EventDetails the roles (creator/participant/nonparticipant) are decided by the CreatorsID instead of the username.