### PR TITLE
Implement participants limit, show current and maximum participants

### DIFF
--- a/app/src/main/java/com/example/insightsshare/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/insightsshare/EventDetailsActivity.java
@@ -35,7 +35,7 @@ public class EventDetailsActivity extends AppCompatActivity {
 
     // View elements
     String eventId, eventCreatorsID;
-    TextView eventName, eventCreator, eventCreationDate, eventPlace, eventDate, eventTime, eventDescription, currentParticipantsNumber, maxParticipantsNumber;
+    TextView eventName, eventCreator, eventCreationDate, eventPlace, eventDate, eventTime, eventDescription, currentParticipantsNumber, maxParticipantsNumber, participantsMaxedNotification;
     RecyclerView participantsView;
     LinearLayout bottomContainer, participantsInfo, eventControl;
     Button joinButton, leaveButton, editButton, deleteButton;
@@ -75,6 +75,7 @@ public class EventDetailsActivity extends AppCompatActivity {
 
         // Participants info on participant view
         participantsInfo = findViewById(R.id.participants_info);
+        participantsMaxedNotification = findViewById(R.id.participants_maxed_notification);
         currentParticipantsNumber = findViewById(R.id.event_current_participants);
         maxParticipantsNumber = findViewById(R.id.event_max_participants);
         participantsView = findViewById(R.id.participants_list);
@@ -213,7 +214,11 @@ public class EventDetailsActivity extends AppCompatActivity {
         });
 
         if (currentParticipants == maxParticipants){
+            participantsMaxedNotification.setVisibility(View.VISIBLE);
             joinButton.setEnabled(false);
+        } else {
+            participantsMaxedNotification.setVisibility(View.GONE);
+            joinButton.setEnabled(true);
         }
     }
 

--- a/app/src/main/java/com/example/insightsshare/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/insightsshare/EventDetailsActivity.java
@@ -35,13 +35,16 @@ public class EventDetailsActivity extends AppCompatActivity {
 
     // View elements
     String eventId, eventCreatorsID;
-    TextView eventName, eventCreator, eventCreationDate, eventPlace, eventDate, eventTime, eventDescription;
+    TextView eventName, eventCreator, eventCreationDate, eventPlace, eventDate, eventTime, eventDescription, currentParticipantsNumber, maxParticipantsNumber;
     RecyclerView participantsView;
     LinearLayout bottomContainer, participantsInfo, eventControl;
     Button joinButton, leaveButton, editButton, deleteButton;
 
     // Get current user
     FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+
+    // Variables to compare the current and maximum number of participants
+    int currentParticipants, maxParticipants;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -72,6 +75,8 @@ public class EventDetailsActivity extends AppCompatActivity {
 
         // Participants info on participant view
         participantsInfo = findViewById(R.id.participants_info);
+        currentParticipantsNumber = findViewById(R.id.event_current_participants);
+        maxParticipantsNumber = findViewById(R.id.event_max_participants);
         participantsView = findViewById(R.id.participants_list);
         participantsView.setLayoutManager(new LinearLayoutManager(this));
 
@@ -100,6 +105,12 @@ public class EventDetailsActivity extends AppCompatActivity {
                 eventTime.setText(eventItem.getEventTime());
                 eventPlace.setText(eventItem.getEventPlace());
                 eventDescription.setText(eventItem.getEventDescription());
+
+                maxParticipants = Integer.valueOf(eventItem.getMaxParticipants());
+                maxParticipantsNumber.setText(eventItem.getMaxParticipants());
+
+                currentParticipants = eventItem.getCurrentParticipants();
+                currentParticipantsNumber.setText(String.valueOf(currentParticipants));
             }
 
             @Override
@@ -152,6 +163,7 @@ public class EventDetailsActivity extends AppCompatActivity {
 
         leaveButton.setOnClickListener(view -> {
             eventRef.child("participantsList").child(user.getUid()).removeValue();
+            eventRef.child("currentParticipants").setValue(--currentParticipants);
             Toast.makeText(EventDetailsActivity.this,R.string.toast_event_leave,Toast.LENGTH_SHORT).show();
         });
     }
@@ -196,8 +208,13 @@ public class EventDetailsActivity extends AppCompatActivity {
 
         joinButton.setOnClickListener(view -> {
             eventRef.child("participantsList").child(user.getUid()).setValue(false);
+            eventRef.child("currentParticipants").setValue(++currentParticipants);
             Toast.makeText(EventDetailsActivity.this,R.string.toast_event_participate,Toast.LENGTH_SHORT).show();
         });
+
+        if (currentParticipants == maxParticipants){
+            joinButton.setEnabled(false);
+        }
     }
 
 

--- a/app/src/main/java/com/example/insightsshare/EventItem.java
+++ b/app/src/main/java/com/example/insightsshare/EventItem.java
@@ -5,13 +5,14 @@ public class EventItem {
     public String eventId, eventName, eventDescription, eventCreator, eventCreatorsID, eventCreationDate, eventPlace,
             eventDate, eventTime, maxParticipants;
 
+    public int currentParticipants;
+
     public EventItem() {
         // Required empty public constructor
      }
 
-
     public EventItem(String eventId, String eventName, String eventDescription, String eventCreator, String eventCreatorsID, String eventCreationDate,
-                     String eventPlace, String eventDate, String eventTime, String maxParticipants) {
+                     String eventPlace, String eventDate, String eventTime, int currentParticipants, String maxParticipants) {
         this.eventId = eventId;
         this.eventName = eventName;
         this.eventDescription= eventDescription;
@@ -21,6 +22,7 @@ public class EventItem {
         this.eventPlace = eventPlace;
         this.eventDate = eventDate;
         this.eventTime = eventTime;
+        this.currentParticipants = currentParticipants;
         this.maxParticipants = maxParticipants;
     }
 
@@ -84,6 +86,14 @@ public class EventItem {
 
     public void setEventTime(String eventTime) {
         this.eventTime = eventTime;
+    }
+
+    public int getCurrentParticipants() {
+        return currentParticipants;
+    }
+
+    public void setCurrentParticipants(int currentParticipants) {
+        this.currentParticipants = currentParticipants;
     }
 
     public String getMaxParticipants() {

--- a/app/src/main/java/com/example/insightsshare/EventListAdapter.java
+++ b/app/src/main/java/com/example/insightsshare/EventListAdapter.java
@@ -39,6 +39,7 @@ public class EventListAdapter extends RecyclerView.Adapter<EventListAdapter.Even
         holder.eventCreationDate.setText(eventItem.getEventCreationDate());
         holder.eventPlace.setText(eventItem.getEventPlace());
         holder.eventDate.setText(eventItem.getEventDate());
+        holder.currentParticipants.setText(String.valueOf(eventItem.getCurrentParticipants()));
         holder.maxParticipants.setText(eventItem.getMaxParticipants());
 
         holder.eventCard.setOnClickListener(new View.OnClickListener() {
@@ -61,7 +62,7 @@ public class EventListAdapter extends RecyclerView.Adapter<EventListAdapter.Even
         CardView eventCard;
 
         TextView eventName, eventCreator, eventCreationDate, eventPlace, eventDate,
-                maxParticipants;
+                currentParticipants, maxParticipants;
 
         public EventViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -73,6 +74,7 @@ public class EventListAdapter extends RecyclerView.Adapter<EventListAdapter.Even
             eventCreationDate = itemView.findViewById(R.id.event_creation_date);
             eventPlace =  itemView.findViewById(R.id.event_place);
             eventDate = itemView.findViewById(R.id.event_date);
+            currentParticipants = itemView.findViewById(R.id.event_current_participants);
             maxParticipants = itemView.findViewById(R.id.event_max_participants);
         }
     }

--- a/app/src/main/java/com/example/insightsshare/EventplanningActivity5.java
+++ b/app/src/main/java/com/example/insightsshare/EventplanningActivity5.java
@@ -158,6 +158,7 @@ public class EventplanningActivity5 extends AppCompatActivity {
                 String ValueDate = datePickerButton.getText().toString();
                 String ValueTime = timePickerButton.getText().toString();
                 String ValuePlace = eventPlace.getEditableText().toString();
+                int ValueCurrentParticipants = 1;
                 String ValueMaxParticipants = maxParticipants.getEditableText().toString();
                 String todayStr = getTodaysDate();
                 String ValueEventCreator = eventCreator.getText().toString();
@@ -165,7 +166,7 @@ public class EventplanningActivity5 extends AppCompatActivity {
 
                 //here the data is collected (to be send to the DB in the next step)
                 EventItem eventEntry = new EventItem(ValueEventId, ValueEventName, ValueEventDescription,
-                        ValueEventCreator, valueEventCreatorsID, todayStr, ValuePlace, ValueDate, ValueTime, ValueMaxParticipants);
+                        ValueEventCreator, valueEventCreatorsID, todayStr, ValuePlace, ValueDate, ValueTime, ValueCurrentParticipants, ValueMaxParticipants);
 
                 //data is stored in the DB
                 assert ValueEventId != null;

--- a/app/src/main/res/color/button_state_color.xml
+++ b/app/src/main/res/color/button_state_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:color="#9c1c4d" />
+    <item android:state_enabled="false" android:color="#BBBBBB" />
+</selector>

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -216,12 +216,61 @@
                     android:layout_marginStart="10dp"
                     android:orientation="vertical">
 
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/participants_list"
                         android:textColor="@color/black"
                         android:textSize="20dp" />
+
+                        <LinearLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="10dp" >
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginRight="10dp"
+                                android:textSize="20dp"
+                                android:text="(" />
+
+                            <TextView
+                                android:id="@+id/event_current_participants"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:textSize="20dp"
+                                android:text="" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginHorizontal="10dp"
+                                android:textSize="20dp"
+                                android:text="/" />
+
+                            <TextView
+                                android:id="@+id/event_max_participants"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:textSize="20dp"
+                                android:text="" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginLeft="10dp"
+                                android:textSize="20dp"
+                                android:text=")" />
+
+                        </LinearLayout>
+
+                    </LinearLayout>
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/participants_list"
@@ -244,7 +293,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginTop="30dp"
-                android:backgroundTint="#9c1c4d"
+                android:backgroundTint="@color/button_state_color"
                 android:text="@string/leave_button" />
 
             <LinearLayout
@@ -259,7 +308,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:backgroundTint="#9c1c4d"
+                    android:backgroundTint="@color/button_state_color"
                     android:text="@string/edit_button" />
 
                 <Button
@@ -268,7 +317,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
                     android:layout_marginTop="10dp"
-                    android:backgroundTint="#9c1c4d"
+                    android:backgroundTint="@color/button_state_color"
                     android:text="@string/delete_button" />
 
             </LinearLayout>
@@ -290,13 +339,20 @@
             android:layout_height="1dp"
             android:background="?android:attr/listDivider" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:layout_marginTop="10dp"
+            android:text="@string/participants_maxed" />
+
         <Button
             android:id="@+id/join_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="28dp"
             android:layout_marginVertical="10dp"
-            android:backgroundTint="#9c1c4d"
+            android:backgroundTint="@color/button_state_color"
             android:text="@string/join_button" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_event_details.xml
+++ b/app/src/main/res/layout/activity_event_details.xml
@@ -340,6 +340,7 @@
             android:background="?android:attr/listDivider" />
 
         <TextView
+            android:id="@+id/participants_maxed_notification"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"

--- a/app/src/main/res/layout/event_row.xml
+++ b/app/src/main/res/layout/event_row.xml
@@ -112,7 +112,7 @@
                 android:textColor="@color/black" />
 
             <TextView
-                android:id="@+id/event_current_participant"
+                android:id="@+id/event_current_participants"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="10dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="event_creation_date">on</string>
 
     <!-- Event Details -->
+    <string name="participants_maxed">This event is currently full!</string>
     <string name="participants_list">Event Participants</string>
     <string name="leave_button">Leave Event</string>
     <string name="join_button">Join</string>


### PR DESCRIPTION
What's New:
- Participants limit implemented, no additional user can join a full event (Join button will be disabled + notification)
- Current and maximum number of event participants in the home page and event details
- Color resource for enabled and disabled button state

![1](https://user-images.githubusercontent.com/54348506/152656578-96ffa967-1d2d-40ae-bd10-72d58ce4d28e.PNG)
![2](https://user-images.githubusercontent.com/54348506/152656580-895787c5-4f24-4dc9-9c06-2ea610bb0b3e.PNG)
![3](https://user-images.githubusercontent.com/54348506/152656582-36a5e9e0-1563-4c9d-9fde-89d7dd9a6fed.PNG)

An @emilieiios : weil jetzt die Anzahl an Teilnehmern relevant ist, muss bei der Event-Erstellung die maximale Anzahl an Teilnehmern als Pflichteingabe gesetzt werden. Sonst stürzt die App ab, falls diese Information in dem Event-Eintrag nicht gefunden werden kann bzw. von dem Event-Ersteller nicht eingegeben ist.

